### PR TITLE
Replace ENTRYPOINT by CMD to run python3 by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apk add --virtual .install_dependencies_paramiko \
 &&  pip install paramiko \
 &&  apk del .install_dependencies_paramiko
 
-ENTRYPOINT ["/bin/sh"]
+CMD python3


### PR DESCRIPTION
Fix #2 
I suspect that the current ENTRYPOINT prevent the correct override of the command `sh`.
For more information about RUN CMD ENTRYPOINT, there is this excellent blog post: https://goinbigdata.com/docker-run-vs-cmd-vs-entrypoint/

Now it starts Python3 by default, like the official Python image does. It is more consistent that a Python image starts Python by default instead of SH.